### PR TITLE
improvement: default table names

### DIFF
--- a/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/AbstractPermission.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/AbstractPermission.java
@@ -9,10 +9,10 @@ import javax.persistence.*;
  *
  * @author Jakub Danek
  */
-@MappedSuperclass
+@Entity
+@Table(name = "discussment_permission")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "permission_type", discriminatorType = DiscriminatorType.STRING)
-@Table(name = "permission")
 public abstract class AbstractPermission extends BaseEntity<PermissionId> {
 
     public static final String PARAM_USER_ID = "userId";

--- a/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/CategoryPermission.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/CategoryPermission.java
@@ -21,7 +21,6 @@ import javax.persistence.*;
                         " AND cp.id.level = org.danekja.discussment.core.accesscontrol.domain.PermissionLevel.GLOBAL")
 })
 @Entity
-@Table(name = "permission")
 @DiscriminatorValue("CATEGORY")
 public class CategoryPermission extends AbstractPermission {
 

--- a/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/DiscussionPermission.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/DiscussionPermission.java
@@ -29,7 +29,6 @@ import javax.persistence.*;
                         " OR dp.id.level = org.danekja.discussment.core.accesscontrol.domain.PermissionLevel.GLOBAL)")
 })
 @Entity
-@Table(name = "permission")
 @DiscriminatorValue("DISCUSSION")
 public class DiscussionPermission extends AbstractPermission {
 

--- a/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/PostPermission.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/PostPermission.java
@@ -30,7 +30,6 @@ import javax.persistence.*;
                         " OR pp.id.level = org.danekja.discussment.core.accesscontrol.domain.PermissionLevel.GLOBAL)")
 })
 @Entity
-@Table(name = "permission")
 @DiscriminatorValue("POST")
 public class PostPermission extends AbstractPermission {
 

--- a/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/TopicPermission.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/accesscontrol/domain/TopicPermission.java
@@ -26,7 +26,6 @@ import javax.persistence.*;
                         " OR tp.id.level = org.danekja.discussment.core.accesscontrol.domain.PermissionLevel.GLOBAL)")
 })
 @Entity
-@Table(name = "permission")
 @DiscriminatorValue("TOPIC")
 public class TopicPermission extends AbstractPermission {
 

--- a/discussment-core/src/main/java/org/danekja/discussment/core/domain/Category.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/domain/Category.java
@@ -14,6 +14,7 @@ import static org.danekja.discussment.core.domain.Category.GET_CATEGORIES;
  */
 
 @Entity
+@Table(name = "discussment_category")
 @NamedQueries({
         @NamedQuery(name = GET_CATEGORIES, query = "SELECT c FROM Category c WHERE id != 1"),
 })

--- a/discussment-core/src/main/java/org/danekja/discussment/core/domain/Discussion.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/domain/Discussion.java
@@ -14,6 +14,7 @@ import static org.danekja.discussment.core.domain.Discussion.GET_DISCUSSIONS_BY_
  */
 
 @Entity
+@Table(name = "discussment_discussion")
 @NamedQueries({
         @NamedQuery(name = GET_DISCUSSIONS_BY_TOPIC_ID,
                 query = "SELECT d FROM Discussion d WHERE d.topic.id = :topicId")

--- a/discussment-core/src/main/java/org/danekja/discussment/core/domain/Post.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/domain/Post.java
@@ -19,6 +19,7 @@ import static org.danekja.discussment.core.domain.Post.GET_REPLIES_FOR_POST;
  * The class represents a post in the discussion.
  */
 @Entity
+@Table(name = "discussment_post")
 @NamedQueries({
         @NamedQuery(name = GET_BY_DISCUSSION,
                 query = "SELECT p FROM Post p WHERE p.discussion.id = :discussionId"),

--- a/discussment-core/src/main/java/org/danekja/discussment/core/domain/Topic.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/domain/Topic.java
@@ -14,6 +14,7 @@ import static org.danekja.discussment.core.domain.Topic.GET_TOPICS_BY_CATEGORY_I
  */
 
 @Entity
+@Table(name = "discussment_topic")
 @NamedQueries({
         @NamedQuery(name = GET_TOPICS_BY_CATEGORY_ID, query = "SELECT t FROM Topic t WHERE t.category.id = :categoryId AND t.id != 1")
 })

--- a/discussment-core/src/main/java/org/danekja/discussment/core/domain/UserPostReputation.java
+++ b/discussment-core/src/main/java/org/danekja/discussment/core/domain/UserPostReputation.java
@@ -13,7 +13,7 @@ import static org.danekja.discussment.core.domain.UserPostReputation.GET_FOR_USE
  * @author Jiri Kryda
  */
 @Entity
-@Table(name = "user_post_reputation")
+@Table(name = "discussment_user_post_reputation")
 @NamedQueries({
         @NamedQuery(name = GET_FOR_USER,
                 query = "SELECT upr FROM UserPostReputation upr WHERE upr.userId = :userId AND upr.post.id = :postId")


### PR DESCRIPTION
All DB tables have their default names prefixed by `discussment_` string. See #37 for more details.